### PR TITLE
Add api to run specific test

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -153,18 +153,17 @@
     name))
 
 
-(defun cargo-process--get-current-file-tests ()
-  "Generate regexp to match test from the current buffer."
-  ;;(with-current-buffer (current-buffer)
-  (save-excursion
-    (goto-char (point-min))
-    (when (string-match "\.rs$" buffer-file-name)
-      (let (result)
-        (while
-            (re-search-forward rust-test-regex  nil t)
-          (let ((name (thing-at-point 'sexp)))
-            (setq result (append result (list name)))))
-        (mapconcat 'identity result "|")))))
+;; (defun cargo-process--get-current-file-tests ()
+;;   "Generate regexp to match test from the current buffer."
+;;   (save-excursion
+;;     (goto-char (point-min))
+;;     (when (string-match "\.rs$" buffer-file-name)
+;;       (let (result)
+;;         (while
+;;             (re-search-forward rust-test-regex  nil t)
+;;           (let ((name (thing-at-point 'sexp)))
+;;             (setq result (append result (list name)))))
+;;         (mapconcat 'identity result "|")))))
 
 
 ;;;###autoload
@@ -235,16 +234,13 @@ Cargo: Run the tests."
   (let ((name (cargo-process--get-current-test)))
     (cargo-process--start "Test" (concat "cargo test " name))))
 
-;; TODO: how run multiple test using cargo ?
-;; FIX: cargo test it_works it_works_another just_a_test
-
 ;; ;;;###autoload
-;; (defun cargo-process-current-file-tests ()
-;;   "Run the Cargo test command for the current file.
-;; Cargo: Run the tests."
-;;   (interactive)
-;;   (let ((names (cargo-process--get-current-file-tests)))
-;;     (cargo-process--start "Test" (s-concat "cargo test " names))))
+(defun cargo-process-current-file-tests ()
+  "Run the Cargo test command for the current file.
+Cargo: Run the tests."
+  (interactive)
+  (let ((filename (file-name-base)))
+    (cargo-process--start "Test" (s-concat "cargo test --test " filename))))
 
 
 ;;;###autoload

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -134,6 +134,9 @@
 ;; I/O tools
 
 
+(defconst rust-test-regex "^[[:space:]]*fn[[:space:]]*"
+  "Regex to find Rust unit test function.")
+
 (defun cargo-process--get-current-test ()
   "Return the current test."
   (let ((start (point))
@@ -141,9 +144,8 @@
     (save-excursion
       (end-of-line)
       (unless (and
-               (search-backward-regexp
-                (s-concat "^[[:space:]]*fn[[:space:]]*") nil t)
-               (save-excursion (go-end-of-defun) (< start (point))))
+               (search-backward-regexp rust-test-regex nil t)
+               (save-excursion (rust-end-of-defun) (< start (point))))
         (error "Unable to find test"))
       (save-excursion
         (search-forward "fn ")
@@ -157,10 +159,9 @@
   (save-excursion
     (goto-char (point-min))
     (when (string-match "\.rs$" buffer-file-name)
-      (let ((regex "^[[:space:]]*fn[[:space:]]*")
-            result)
+      (let (result)
         (while
-            (re-search-forward regex nil t)
+            (re-search-forward rust-test-regex  nil t)
           (let ((name (thing-at-point 'sexp)))
             (setq result (append result (list name)))))
         (mapconcat 'identity result "|")))))

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -233,7 +233,7 @@ Cargo: Run the tests."
 Cargo: Run the tests."
   (interactive)
   (let ((name (cargo-process--get-current-test)))
-    (cargo-process--start "Test" (s-concat "cargo test " name))))
+    (cargo-process--start "Test" (concat "cargo test " name))))
 
 ;; TODO: how run multiple test using cargo ?
 ;; FIX: cargo test it_works it_works_another just_a_test

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -153,17 +153,17 @@
 
 (defun cargo-process--get-current-file-tests ()
   "Generate regexp to match test from the current buffer."
-  (with-current-buffer (current-buffer)
-    (save-excursion
-      (goto-char (point-min))
-      (when (string-match "\.rs$" buffer-file-name)
-        (let ((regex "^[[:space:]]*fn[[:space:]]*")
-              result)
-          (while
-              (re-search-forward regex nil t)
-            (let ((name (thing-at-point 'sexp)))
-              (setq result (append result (list name)))))
-          (mapconcat 'identity result "|"))))))
+  ;;(with-current-buffer (current-buffer)
+  (save-excursion
+    (goto-char (point-min))
+    (when (string-match "\.rs$" buffer-file-name)
+      (let ((regex "^[[:space:]]*fn[[:space:]]*")
+            result)
+        (while
+            (re-search-forward regex nil t)
+          (let ((name (thing-at-point 'sexp)))
+            (setq result (append result (list name)))))
+        (mapconcat 'identity result "|")))))
 
 
 ;;;###autoload

--- a/cargo.el
+++ b/cargo.el
@@ -34,6 +34,9 @@
 ;;  * C-c C-c C-t - cargo-process-test
 ;;  * C-c C-c C-u - cargo-process-update
 ;;  * C-c C-c C-c - cargo-process-repeat
+;;  * C-c C-c C-f - cargo-process-current-test
+;;  * C-c C-c C-i - cargo-process-current-file-tests
+
 ;;
 ;;; Code:
 
@@ -62,6 +65,8 @@
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-t") 'cargo-process-test)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-u") 'cargo-process-update)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-c") 'cargo-process-repeat)
+(define-key cargo-minor-mode-map (kbd "C-c C-c C-f") 'cargo-process-current-test)
+(define-key cargo-minor-mode-map (kbd "C-c C-c C-i") 'cargo-process-current-file-tests)
 
 (provide 'cargo)
 ;;; cargo.el ends here


### PR DESCRIPTION
With this file : 

``` rust
#[test]
fn it_works() {
}

#[test]
fn it_works_another() {

}

#[test]
fn just_a_test() {

}
```

When pointer is in `it_works_another`, with <kbd> M-x cargo-process-current-test</kbd>, cargo is called to run specific test : 

``` bash
-*- mode: cargo-process; default-directory: "~/Perso/cargo.el/var/hello_world/src/" -*-
Cargo-Process started at Mon Nov  2 12:24:19

cargo test it_works_another
     Running /home/nlamirault/Perso/cargo.el/var/hello_world/target/debug/hello_world-9f660b2810b4c89b

running 1 test
test it_works_another ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured

   Doc-tests hello_world

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
```

There is also another method to run all test from current file, but actually it doesn't work : 

``` bash
-*- mode: cargo-process; default-directory: "~/Perso/cargo.el/var/hello_world/src/" -*-
Cargo-Process started at Mon Nov  2 12:19:12

cargo test it_works|it_works_another|just_a_test
/usr/bin/bash: it_works_another: command not found
/usr/bin/bash: just_a_test: command not found
An unknown error occurred

To learn more, run the command again with --verbose.

```

Another command which fails (only 2 tests are executed) : 

``` bash
cargo test it_works it_works_another just_a_test
Running target/debug/hello_world-9f660b2810b4c89b

running 2 tests
test it_works ... ok
test it_works_another ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured

   Doc-tests hello_world

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured

```

I don't really know if it is possible to launch all tests from one file with Cargo.

Signed-off-by: Nicolas Lamirault nicolas.lamirault@gmail.com
