### PR TITLE
NEW added cargo-process-run-example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You will now have the following key combinations at your disposal:
  <kbd>C-c C-c C-n</kbd> | cargo-process-new
  <kbd>C-c C-c C-i</kbd> | cargo-process-init
  <kbd>C-c C-c C-r</kbd> | cargo-process-run
+ <kbd>C-c C-c C-x</kbd> | cargo-process-run-example
  <kbd>C-c C-c C-s</kbd> | cargo-process-search
  <kbd>C-c C-c C-t</kbd> | cargo-process-test
  <kbd>C-c C-c C-u</kbd> | cargo-process-update

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -23,19 +23,20 @@
 ;; Cargo Process Major mode.
 ;; Used to run Cargo background processes.
 ;; Current supported Cargo functions:
-;;  * cargo-process-bench  - Run the benchmarks.
-;;  * cargo-process-build  - Compile the current project.
-;;  * cargo-process-clean  - Remove the target directory.
-;;  * cargo-process-doc    - Build this project's and its dependencies' documentation.
-;;  * cargo-process-new    - Create a new cargo project.
-;;  * cargo-process-init   - Create a new cargo project inside an existing directory.
-;;  * cargo-process-run    - Build and execute src/main.rs.
-;;  * cargo-process-search - Search registry for crates.
-;;  * cargo-process-test   - Run the tests.
-;;  * cargo-process-update - Update dependencies listed in Cargo.lock.
-;;  * cargo-process-repeat - Run the last cargo-process command.
-;;  * cargo-process-current-test         - Run the current unit test.
-;;  * cargo-process-current-file-tests   -  the current file unit tests.
+;;  * cargo-process-bench              - Run the benchmarks.
+;;  * cargo-process-build              - Compile the current project.
+;;  * cargo-process-clean              - Remove the target directory.
+;;  * cargo-process-doc                - Build this project's and its dependencies' documentation.
+;;  * cargo-process-new                - Create a new cargo project.
+;;  * cargo-process-init               - Create a new cargo project inside an existing directory.
+;;  * cargo-process-run                - Build and execute src/main.rs.
+;;  * cargo-process-run-example        - Build and execute with --example <name>.
+;;  * cargo-process-search             - Search registry for crates.
+;;  * cargo-process-test               - Run all unit tests.
+;;  * cargo-process-update             - Update dependencies listed in Cargo.lock.
+;;  * cargo-process-repeat             - Run the last cargo-process command.
+;;  * cargo-process-current-test       - Run the current unit test.
+;;  * cargo-process-current-file-tests - Run the current file unit tests.
 
 ;;
 ;;; Code:
@@ -272,6 +273,15 @@ With the prefix argument, modify the command's invocation.
 Cargo: Build and execute src/main.rs."
   (interactive)
   (cargo-process--start "Run" "cargo run"))
+
+;;;###autoload
+(defun cargo-process-run-example (command)
+  "Run the Cargo run command --example <name>.
+With the prefix argument, modify the command's invocation.
+Cargo: Build and execute with --example <name>."
+  (interactive "sExample name: ")
+  (cargo-process--start (concat "Example " command)
+                        (concat "cargo run --example " command)))
 
 ;;;###autoload
 (defun cargo-process-search (search-term)

--- a/cargo.el
+++ b/cargo.el
@@ -32,6 +32,7 @@
 ;;  * C-c C-c C-n - cargo-process-new
 ;;  * C-c C-c C-i - cargo-process-init
 ;;  * C-c C-c C-r - cargo-process-run
+;;  * C-c C-c C-x - cargo-process-run-example
 ;;  * C-c C-c C-s - cargo-process-search
 ;;  * C-c C-c C-t - cargo-process-test
 ;;  * C-c C-c C-u - cargo-process-update
@@ -63,6 +64,7 @@
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-n") 'cargo-process-new)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-i") 'cargo-process-init)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-r") 'cargo-process-run)
+(define-key cargo-minor-mode-map (kbd "C-c C-c C-x") 'cargo-process-run-example)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-s") 'cargo-process-search)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-t") 'cargo-process-test)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-u") 'cargo-process-update)


### PR DESCRIPTION
Closes https://github.com/kwrooijen/cargo.el/issues/9.

@MasonRemaley I changed the function from `cargo-process-example` to `cargo-process-run-example` as an FYI. The keyboard shortcut is still the same.
