### PR TITLE
[master] Add dependency to suppress warning.

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -43,6 +43,7 @@
 
 (require 'compile)
 (require 'button)
+(require 'rust-mode)
 
 (defgroup cargo-process nil
   "Cargo Process group."


### PR DESCRIPTION
When I build on my Emacs, it outputs a warning about an undeclared function. I added `require rust-mode` to suppress this warning.
