### PR TITLE
To hide the "Compiling" in mode-line when process exit.

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -133,6 +133,7 @@
 
 (defun cargo-process--finished-sentinel (process event)
   "Execute after PROCESS return and EVENT is 'finished'."
+  (compilation-sentinel process event)
   (when (equal event "finished\n")
     (message "Cargo Process finished.")))
 


### PR DESCRIPTION
Call compilation's sentinel.

To hide the "Compiling" in mode-line.
