### PR TITLE
Added cargo clippy subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You will now have the following key combinations at your disposal:
  <kbd>C-c C-c C-o</kbd> | cargo-process-current-file-tests
  <kbd>C-c C-c C-m</kbd> | cargo-process-fmt
  <kbd>C-c C-c C-k</kbd> | cargo-process-check
+ <kbd>C-c C-c C-K</kbd> | cargo-process-clippy
 
 Before executing the task, Emacs will prompt you to save any modified buffers
 associated with the current Cargo project. Setting `compilation-ask-about-save`
@@ -56,4 +57,10 @@ In order to run `cargo-process-check` you need to have the `cargo-check` package
 
 ```
 cargo install cargo-check
+```
+
+In order to run `cargo-process-clippy` you need to have the `clippy` package installed.
+
+```
+cargo install clippy
 ```

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -39,6 +39,7 @@
 ;;  * cargo-process-current-file-tests - Run the current file unit tests.
 ;;  * cargo-process-fmt                - Run the optional cargo command fmt.
 ;;  * cargo-process-check              - Run the optional cargo command check.
+;;  * cargo-process-clippy             - Run the optional cargo command clippy.
 
 ;;
 ;;; Code:
@@ -332,6 +333,15 @@ Cargo: Check compile the current project.
 Requires cargo-check to be installed."
   (interactive)
   (cargo-process--start "Check" "cargo check"))
+
+;;;###autoload
+(defun cargo-process-clippy ()
+  "Run the Cargo clippy command.
+With the prefix argument, modify the command's invocation.
+Cargo: Clippy compile the current project.
+Requires Cargo clippy to be installed."
+  (interactive)
+  (cargo-process--start "Clippy" "cargo clippy"))
 
 ;;;###autoload
 (defun cargo-process-repeat ()

--- a/cargo.el
+++ b/cargo.el
@@ -41,6 +41,7 @@
 ;;  * C-c C-c C-o - cargo-process-current-file-tests
 ;;  * C-c C-c C-m - cargo-process-fmt
 ;;  * C-c C-c C-k - cargo-process-check
+;;  * C-c C-c C-K - cargo-process-clippy
 
 ;;
 ;;; Code:
@@ -76,6 +77,7 @@
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-o") 'cargo-process-current-file-tests)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-m") 'cargo-process-fmt)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-k") 'cargo-process-check)
+(define-key cargo-minor-mode-map (kbd "C-c C-c C-K") 'cargo-process-clippy)
 
 (provide 'cargo)
 ;;; cargo.el ends here


### PR DESCRIPTION
This commit adds the optional cargo clippy subcommand to the list of available subcommands.

I settled on C-c C-c C-K to be similar to cargo-check, with the implication that clippy is like a bigger check, but I'm not overly attached to the binding if anyone has a different preference.
