### PR TITLE
Enable lexical binding

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -1,4 +1,4 @@
-;;; cargo-process.el --- Cargo Process Major Mode
+;;; cargo-process.el --- Cargo Process Major Mode -*-lexical-binding: t-*-
 
 ;; Copyright (C) 2015  Kevin W. van Rooijen
 


### PR DESCRIPTION
Fixes the "error: (void-variable buffer)" when recompiling using `g`
inside a cargo window.
