### PR TITLE
Customizable path to executable

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -53,6 +53,11 @@
   :prefix "cargo-process-"
   :group 'cargo)
 
+(defcustom cargo-process--custom-path-to-bin ""
+  "Custom path to the directory containing the cargo executable"
+  :type 'directory
+  :group 'cargo-process)
+
 (defvar cargo-process-mode-map
   (nconc (make-sparse-keymap) compilation-mode-map)
   "Keymap for Cargo major mode.")
@@ -145,7 +150,12 @@
 (defun cargo-process--start (name command)
   "Start the Cargo process NAME with the cargo command COMMAND."
   (let ((buffer (concat "*Cargo " name "*"))
-        (command (cargo-process--maybe-read-command command))
+        (command (cargo-process--maybe-read-command
+                  (if (string= cargo-process--custom-path-to-bin "")
+                      command
+                    (concat (file-name-as-directory
+                             cargo-process--custom-path-to-bin)
+                            command))))
         (project-root (cargo-process--project-root)))
     (save-some-buffers (not compilation-ask-about-save)
                        (lambda ()

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -53,7 +53,7 @@
   :prefix "cargo-process-"
   :group 'cargo)
 
-(defcustom cargo-process--custom-path-to-bin ""
+(defcustom cargo-process--custom-path-to-bin nil
   "Custom path to the directory containing the cargo executable"
   :type 'directory
   :group 'cargo-process)
@@ -149,14 +149,11 @@
 
 (defun cargo-process--start (name command)
   "Start the Cargo process NAME with the cargo command COMMAND."
-  (let ((buffer (concat "*Cargo " name "*"))
-        (command (cargo-process--maybe-read-command
-                  (if (string= cargo-process--custom-path-to-bin "")
-                      command
-                    (concat (file-name-as-directory
-                             cargo-process--custom-path-to-bin)
-                            command))))
-        (project-root (cargo-process--project-root)))
+  (let* ((buffer (concat "*Cargo " name "*"))
+         (path cargo-process--custom-path-to-bin)
+         (path (and path (file-name-as-directory path)))
+         (command (cargo-process--maybe-read-command (concat path command)))
+         (project-root (cargo-process--project-root)))
     (save-some-buffers (not compilation-ask-about-save)
                        (lambda ()
                          (and project-root


### PR DESCRIPTION
Change cargo-process to maybe use a custom path for the cargo executable, if one is provided.

This adds a customizable variable, `cargo-process--custom-path-to-bin`, that, if left alone, will (hopefully) make `cargo.el` behave exactly the same as before, and, when set to anything other than an empty string, will adjust the called commands to use the defined path.

I made these changes because Emacs would not find Cargo on my machine (and having to type <kbd>C-u-c-c-b-HOME-~/.cargo/bin/-RET</kbd> every time I needed to compile my code was a bit too much).

Please take this with a grain of salt, as I never coded any elisp before. Everything works in every test that I made, but I'm still unsure.