### PR TITLE
Display error explaination in a markdown-mode buffer

### DIFF
--- a/cargo.el
+++ b/cargo.el
@@ -5,7 +5,7 @@
 ;; Author: Kevin W. van Rooijen <kevin.van.rooijen@attichacker.com>
 ;; Version  : 0.4.0
 ;; Keywords: tools
-;; Package-Requires: ((emacs "24.3") (rust-mode "0.2.0"))
+;; Package-Requires: ((emacs "24.3") (rust-mode "0.2.0") (markdown-mode "2.4"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Before:
![cargo-before](https://user-images.githubusercontent.com/5273820/34471462-c1fdabd0-ef4a-11e7-8664-0e68b2518a67.jpg)
After:
![cargo](https://user-images.githubusercontent.com/5273820/34471463-c9378c72-ef4a-11e7-9fad-84b53c44534d.jpg)
