### PR TITLE
Fixes and improvement

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -223,12 +223,12 @@ Always set to nil if cargo-process--enable-rust-backtrace is nil"
         (setenv cargo-process--rust-backtrace "1")
       (setenv cargo-process--rust-backtrace nil))))
 
-(defun cargo-process--start (name command &optional last-command)
+(defun cargo-process--start (name command &optional last-cmd)
   "Start the Cargo process NAME with the cargo command COMMAND."
   (set-rust-backtrace command)
   (let* ((buffer (concat "*Cargo " name "*"))
          (cmd
-          (or last-command
+          (or last-cmd
               (cargo-process--maybe-read-command
                (mapconcat #'identity (list cargo-process--custom-path-to-bin
                                            command

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -60,6 +60,14 @@
   :type 'file
   :group 'cargo-process)
 
+(defcustom cargo-process--rustc-cmd
+  (or (executable-find "rustc")
+      (expand-file-name "rustc" "~/.cargo/bin")
+      "/usr/local/bin/rustc")
+  "Custom path to the rustc executable"
+  :type 'file
+  :group 'cargo-process)
+
 (defcustom cargo-process--enable-rust-backtrace nil
   "Set RUST_BACKTRACE environment variable to 1 for tasks test and run"
   :group 'cargo-process)
@@ -245,7 +253,7 @@ Always set to nil if cargo-process--enable-rust-backtrace is nil"
   (save-excursion
     (with-help-window (help-buffer)
       (princ (shell-command-to-string
-              (concat "rustc --explain=" errno)))
+              (concat cargo-process--rustc-cmd " --explain=" errno)))
       (with-current-buffer standard-output
         (buffer-string)))))
 

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -55,7 +55,10 @@
   :prefix "cargo-process-"
   :group 'cargo)
 
-(defcustom cargo-process--custom-path-to-bin "cargo"
+(defcustom cargo-process--custom-path-to-bin
+  (or (executable-find "cargo")
+      (expand-file-name "cargo" "~/.cargo/bin")
+      "/usr/local/bin/cargo")
   "Custom path to the cargo executable"
   :type 'file
   :group 'cargo-process)


### PR DESCRIPTION
Tested on mac OS, cargo version 0.24.0, rustc version 1.23.0.

Without commit 309cc36, `cargo-process--explain-help` fails because `rustc` was not found.