### PR TITLE
Add keybindings to docstring so they show up in `describe-mode`.

### DIFF
--- a/cargo.el
+++ b/cargo.el
@@ -59,7 +59,9 @@
 
 ;;;###autoload
 (define-minor-mode cargo-minor-mode
-  "Cargo minor mode. Used to hold keybindings for cargo-mode"
+  "Cargo minor mode. Used to hold keybindings for cargo-mode.
+
+\\{cargo-minor-mode-map}"
   nil " cargo" cargo-minor-mode-map)
 
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-e") 'cargo-process-bench)


### PR DESCRIPTION
This makes the keybindings more discoverable.