### PR TITLE
Use cargo-metadata command to learn about workspace root

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -177,9 +177,19 @@
                 (buffer-substring-no-properties (line-beginning-position)
                                                 (line-end-position))))
 
+(defun cargo-process--workspace-root ()
+  "Find the worksapce root using `cargo metadata`."
+  (let* ((metadata-text (shell-command-to-string
+			 "cargo metadata --format-version 1 --no-deps"))
+	 (metadata-json (json-read-from-string metadata-text))
+	 (workspace-root (alist-get 'workspace_root metadata-json)))
+    workspace-root))
+
 (defun cargo-process--project-root ()
   "Find the root of the current Cargo project."
-  (let ((root (locate-dominating-file (or buffer-file-name default-directory) "Cargo.toml")))
+  (let* ((guess-root (locate-dominating-file (or buffer-file-name default-directory) "Cargo.toml"))
+	 (workspace-root (cargo-process--workspace-root))
+	 (root (or workspace-root guess-root)))
     (and root (file-truename root))))
 
 (define-derived-mode cargo-process-mode compilation-mode "Cargo-Process."


### PR DESCRIPTION
Hi! recently Cargo changed the way it reports errors (they are now realative to the workspace root), and this commits fixes cargo.el to support it. 

The idea is to ask Cargo itself about where's the workspace root, and fallback to old `Cargo.toml` discovery, if that fails. 