### PR TITLE
Added cargo edit subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,5 @@ In order to run `cargo-process-{add,rm,upgrade}` you need to have the `cargo-edi
 ```
 cargo install cargo-edit
 ```
+For completion in `cargo-process-add`, configure `cargo-process-favorite-crates`.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ You will now have the following key combinations at your disposal:
  <kbd>C-c C-c C-m</kbd> | cargo-process-fmt
  <kbd>C-c C-c C-k</kbd> | cargo-process-check
  <kbd>C-c C-c C-S-k</kbd> | cargo-process-clippy
+ <kbd>C-c C-c C-a</kbd> | cargo-process-add
+ <kbd>C-c C-c C-S-d</kbd> | cargo-process-rm
+ <kbd>C-c C-c C-S-u</kbd> | cargo-process-upgrade
 
 Before executing the task, Emacs will prompt you to save any modified buffers
 associated with the current Cargo project. Setting `compilation-ask-about-save`
@@ -70,6 +73,9 @@ Here's a list of commands and their default value.
 (setq cargo-process--command-fmt "cargo fmt")
 (setq cargo-process--command-check "cargo check")
 (setq cargo-process--command-clippy "cargo clippy")
+(setq cargo-process--command-add "cargo add")
+(setq cargo-process--command-rm "cargo rm")
+(setq cargo-process--command-upgrade "cargo upgrade")
 ```
 
 ### Advanced usage
@@ -103,3 +109,10 @@ In order to run `cargo-process-clippy` you need to have the `clippy` package ins
 ```
 cargo install clippy
 ```
+
+In order to run `cargo-process-{add,rm,upgrade}` you need to have the `cargo-edit` package installed.
+
+```
+cargo install cargo-edit
+```
+

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -42,6 +42,10 @@
 ;;  * cargo-process-fmt                - Run the optional cargo command fmt.
 ;;  * cargo-process-check              - Run the optional cargo command check.
 ;;  * cargo-process-clippy             - Run the optional cargo command clippy.
+;;  * cargo-process-add                - Run the optional cargo command add.
+;;  * cargo-process-rm                 - Run the optional cargo command rm.
+;;  * cargo-process-upgrade            - Run the optional cargo command upgrade.
+
 
 ;;
 ;;; Code:
@@ -123,6 +127,13 @@
 (defvar cargo-process--command-check "check")
 
 (defvar cargo-process--command-clippy "clippy")
+
+(defvar cargo-process--command-add "add")
+
+(defvar cargo-process--command-rm "rm")
+
+(defvar cargo-process--command-upgrade "upgrade")
+
 
 (defface cargo-process--ok-face
   '((t (:foreground "#00ff00")))
@@ -505,6 +516,45 @@ Cargo: Clippy compile the current project.
 Requires Cargo clippy to be installed."
   (interactive)
   (cargo-process--start "Clippy" cargo-process--command-clippy))
+
+;;;###autoload
+(defun cargo-process-add (crate)
+  "Run the Cargo add command.
+With the prefix argument, modify the command's invocation.
+CRATE is the name of the crate to add.
+Cargo: This command allows you to add a dependency to a Cargo.toml manifest file."
+  (interactive "sCrate name: ")
+  (cargo-process--start "Add" (concat cargo-process--command-add
+									  " "
+									  crate)))
+
+;;;###autoload
+(defun cargo-process-rm (crate)
+  "Run the Cargo rm command.
+With the prefix argument, modify the command's invocation.
+CRATE is the name of the crate to remove.
+Cargo: Remove a dependency from a Cargo.toml manifest file."
+  (interactive "sCrate name: ")
+  (cargo-process--start "Remove" (concat cargo-process--command-rm
+										 " "
+										 crate)))
+;;;###autoload
+(defun cargo-process-upgrade (&optional all crates)
+  "Run the Cargo update command.
+With the prefix argument, modify the command's invocation.
+If ALL is t then update all crates, otherwise specify CRATES.
+Cargo: Upgrade dependencies as specified in the local manifest file"
+  (interactive)
+  (let ((all (when (or all
+					   (y-or-n-p "Upgrade all crates? "))
+			   "--all"))
+		(crates (if (not all)
+					(read-string "Crates to upgrade: ")
+				  nil)))
+	(cargo-process--start "Upgrade" (concat cargo-process--command-upgrade
+											" "
+											all
+											crates))))
 
 ;;;###autoload
 (defun cargo-process-repeat ()

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -523,7 +523,7 @@ Requires Cargo clippy to be installed."
 With the prefix argument, modify the command's invocation.
 CRATE is the name of the crate to add.
 Cargo: This command allows you to add a dependency to a Cargo.toml manifest file."
-  (interactive "sCrate name: ")
+  (interactive "sCrate(s) to add: ")
   (cargo-process--start "Add" (concat cargo-process--command-add
 									  " "
 									  crate)))
@@ -534,7 +534,7 @@ Cargo: This command allows you to add a dependency to a Cargo.toml manifest file
 With the prefix argument, modify the command's invocation.
 CRATE is the name of the crate to remove.
 Cargo: Remove a dependency from a Cargo.toml manifest file."
-  (interactive "sCrate name: ")
+  (interactive "sCrate to remove: ")
   (cargo-process--start "Remove" (concat cargo-process--command-rm
 										 " "
 										 crate)))

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -559,7 +559,7 @@ Cargo: Remove a dependency from a Cargo.toml manifest file."
 					 (cargo-process--project-root) "Cargo.toml"))))
 	  (if deplist
 		  (completing-read "Crate to remove: "
-						   deplist)
+						   deplist nil t)
 		(progn
 		  (message "No crates used in current project.")
 		  nil)))))
@@ -581,7 +581,7 @@ Cargo: Upgrade dependencies as specified in the local manifest file"
 							 (y-or-n-p "Upgrade all crates? "))
 					 "--all"))
 			  (crates (if (not all)
-						  (completing-read "Crates to upgrade: " deplist)
+						  (completing-read "Crates to upgrade: " deplist nil t)
 						nil)))
 		  (cargo-process--start "Upgrade" (concat cargo-process--command-upgrade
 												  " "

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -134,6 +134,8 @@
 
 (defvar cargo-process--command-upgrade "upgrade")
 
+(defvar cargo-process-favorite-crates nil)
+
 
 (defface cargo-process--ok-face
   '((t (:foreground "#00ff00")))
@@ -539,9 +541,10 @@ Requires Cargo clippy to be installed."
 (defun cargo-process-add (crate)
   "Run the Cargo add command.
 With the prefix argument, modify the command's invocation.
-CRATE is the name of the crate to add.
+CRATES is the name of the crate to add.
 Cargo: This command allows you to add a dependency to a Cargo.toml manifest file."
-  (interactive "sCrate(s) to add: ")
+  (interactive (list
+				(completing-read "Crate(s) to add: " cargo-process-favorite-crates)))
   (cargo-process--start "Add" (concat cargo-process--command-add
 									  " "
 									  crate)))
@@ -581,7 +584,7 @@ Cargo: Upgrade dependencies as specified in the local manifest file"
 							 (y-or-n-p "Upgrade all crates? "))
 					 "--all"))
 			  (crates (if (not all)
-						  (completing-read "Crates to upgrade: " deplist nil t)
+						  (completing-read "Crate(s) to upgrade: " deplist nil 'confirm)
 						nil)))
 		  (cargo-process--start "Upgrade" (concat cargo-process--command-upgrade
 												  " "

--- a/cargo.el
+++ b/cargo.el
@@ -43,6 +43,9 @@
 ;;  * C-c C-c C-m - cargo-process-fmt
 ;;  * C-c C-c C-k - cargo-process-check
 ;;  * C-c C-c C-K - cargo-process-clippy
+;;  * C-c C-c C-a - cargo-process-add
+;;  * C-c C-c C-D - cargo-process-rm
+;;  * C-c C-c C-U - cargo-process-upgrade
 
 ;;
 ;;; Code:
@@ -82,6 +85,9 @@
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-m") 'cargo-process-fmt)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-k") 'cargo-process-check)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-S-k") 'cargo-process-clippy)
+(define-key cargo-minor-mode-map (kbd "C-c C-c C-a") 'cargo-process-add)
+(define-key cargo-minor-mode-map (kbd "C-c C-c C-S-d") 'cargo-process-rm)
+(define-key cargo-minor-mode-map (kbd "C-c C-c C-S-u") 'cargo-process-upgrade)
 
 (provide 'cargo)
 ;;; cargo.el ends here


### PR DESCRIPTION
This PR adds the optional subcommands cargo add, rm, and upgrade from [cargo-edit](https://github.com/killercup/cargo-edit).

I had trouble settling on bindings, but i think that the use of uppercase `'D'` and `'U'` is reminiscent of keybindings in other modes, like dired or package.el.

~~It would be cool to parse the Cargo.toml to be able to provide completion for cargo rm and cargo upgrade, but I'm not sure how to go about doing that.~~ There's now completion support for cargo rm and cargo upgrade.