### PR TITLE
Added Fmt and Search to manifest exclusions

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -88,7 +88,7 @@
   "Keymap for Cargo major mode.")
 
 (defvar cargo-process--no-manifest-commands
-  '("New" "Init")
+  '("New" "Init" "Search" "Fmt")
   "These commands should not specify a manifest file.")
 
 (defvar cargo-process-last-command nil "Command used last for repeating.")


### PR DESCRIPTION
This PR addresses `--manifest-path` errors when executing the `search` and `fmt` commands by adding them to the `cargo-process--no-manifest-commands`.

`cargo search` gives the following error while editing a project file:
```
error: Found argument '--manifest-path' which wasn't expected, or isn't valid in this context
```
`cargo fmt` doesn't seem to support `--manifest-path` anymore and gives the following error:
```
Invalid argument:
```
Refs: #64