### PR TITLE
Fixes for backtrace on run + test

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -77,6 +77,7 @@
 
 (defcustom cargo-process--enable-rust-backtrace nil
   "Set RUST_BACKTRACE environment variable to 1 for tasks test and run"
+  :type 'bool
   :group 'cargo-process)
 
 (defcustom cargo-process--command-flags ""

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -236,10 +236,10 @@
 (defun set-rust-backtrace (command)
   "Set RUST_BACKTRACE variable depending on the COMMAND used.
 Always set to nil if cargo-process--enable-rust-backtrace is nil"
-  (when cargo-process--enable-rust-backtrace
-    (if (string-match "cargo \\(test\\|run\\)" command)
-        (setenv cargo-process--rust-backtrace "1")
-      (setenv cargo-process--rust-backtrace nil))))
+  (if (and cargo-process--enable-rust-backtrace
+           (string-match "\\(test\\|run\\)" command))
+      (setenv cargo-process--rust-backtrace "1")
+    (setenv cargo-process--rust-backtrace nil)))
 
 (defun cargo-process--workspace-root ()
   "Find the workspace root using `cargo metadata`."


### PR DESCRIPTION
* Added a missing type for `cargo-process--enable-rust-backtrace`
* Fixed `set-rust-backtrace` such that if `cargo-process--enable-rust-backtrace` is set and command is "run" or "test" (before it would check for "cargo run" or "cargo test" while the input didn't contain "cargo"), then it sets `cargo-process--rust-backtrace`. Additionally, if `cargo-process--enable-rust-backtrace` is not set then it resets `cargo-process--rust-backtrace`. Otherwise, it is enabled for the next commands as well even if `cargo-process--enable-rust-backtrace` is disabled.

I found the bug while testing with this:
```elisp
(defun msk/cargo-run-backtrace ()
  (interactive)
  (let ((cargo-process--enable-rust-backtrace t))
    (cargo-process-run)))
```