### PR TITLE
Fix `cargo-process-test-mod-regexp`

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -196,7 +196,7 @@
 (defconst cargo-process-test-regexp "^[[:space:]]*fn[[:space:]]*"
   "Regex to find Rust unit test function.")
 
-(defconst cargo-process-test-mod-regexp "^[[:space:]]*mod[[:space:]]*\\w+[[:space:]]*{")
+(defconst cargo-process-test-mod-regexp "^[[:space:]]*mod[[:space:]]+[[:word:][:multibyte:]_][[:word:][:multibyte:]_[:digit:]]*[[:space:]]*{")
 
 (defconst cargo-process-font-lock-keywords
   '(("^error\\:?" . 'cargo-process--error-face)

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -365,7 +365,7 @@ Meant to be run as a `compilation-filter-hook'."
       (let* ((line (buffer-substring-no-properties (line-beginning-position)
                                                    (line-end-position)))
              (line (string-trim-left line))
-             (lines (split-string line " "))
+             (lines (split-string line " \\|{"))
              (mod (cadr lines)))
         mod))))
 


### PR DESCRIPTION
Fixes #75 

Use the proper regexp to capture valid Rust identifiers