### PR TITLE
Fix the logic to get the module name if in an enclosing module

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -365,7 +365,7 @@ Meant to be run as a `compilation-filter-hook'."
       (let* ((line (buffer-substring-no-properties (line-beginning-position)
                                                    (line-end-position)))
              (line (string-trim-left line))
-             (lines (split-string line " "))
+             (lines (split-string line " \\|{"))
              (mod (cadr lines)))
         mod))))
 


### PR DESCRIPTION
A valid Rust file could have the following source:

```rust
mod foobar{
// ... rest of module
}
```

And given the current implementation the above example would return `foobar{`
as the module name when what we want is `foobar`.

This commit fixes the string parsing to allow for this possibility.