### PR TITLE
Fix cargo-process--enable-rust-backtrace defcustom :type typo

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -77,7 +77,7 @@
 
 (defcustom cargo-process--enable-rust-backtrace nil
   "Set RUST_BACKTRACE environment variable to 1 for tasks test and run"
-  :type 'bool
+  :type 'boolean
   :group 'cargo-process)
 
 (defcustom cargo-process--command-flags ""


### PR DESCRIPTION
Fixes a typo in the customization type symbol used for `cargo-process--enable-rust-backtrace`.  With the typo, when trying to customize it, an error occurs saying: `widget-apply: Symbol’s function definition is void: nil`, and you cannot customize it because of this.  Changing the symbol to `boolean`, as described in the Elisp manual section 14.4.1 of my GNU Emacs 25.2, fixes it.