### PR TITLE
Add a function for running cargo expand

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ You will now have the following key combinations at your disposal:
  <kbd>C-c C-c C-c</kbd> | cargo-process-repeat
  <kbd>C-c C-c C-f</kbd> | cargo-process-current-test
  <kbd>C-c C-c C-o</kbd> | cargo-process-current-file-tests
+ <kbd>C-c C-c C-p</kbd> | cargo-process-expand
+ <kbd>C-c C-c C-S-p</kbd> | cargo-process-current-file-expand
+ <kbd>C-c C-c M-p</kbd> | cargo-process-current-file-expand-and-compile
  <kbd>C-c C-c C-m</kbd> | cargo-process-fmt
  <kbd>C-c C-c C-k</kbd> | cargo-process-check
  <kbd>C-c C-c C-S-k</kbd> | cargo-process-clippy
@@ -70,6 +73,8 @@ Here's a list of commands and their default value.
 (setq cargo-process--command-current-test "test")
 (setq cargo-process--command-current-file-tests "test")
 (setq cargo-process--command-update "update")
+(setq cargo-process--command-expand "expand --color never")
+(setq cargo-process--command-expand "expand --color never")
 (setq cargo-process--command-fmt "fmt")
 (setq cargo-process--command-check "check")
 (setq cargo-process--command-clippy "clippy")
@@ -91,6 +96,15 @@ processes.
 [compilation mode]: https://www.gnu.org/software/emacs/manual/html_node/emacs/Compilation-Mode.html
 
 ## Notes
+
+In order to run `cargo-process-expand`,
+`cargo-process-current-file-expand`, or
+`cargo-process-current-file-expand-and-compile` you need to have the
+`cargo-expand` package installed.
+
+```
+cargo install cargo-expand
+```
 
 In order to run `cargo-process-fmt` you need to have the `rustfmt` package installed.
 
@@ -116,4 +130,3 @@ In order to run `cargo-process-{add,rm,upgrade}` you need to have the `cargo-edi
 cargo install cargo-edit
 ```
 For completion in `cargo-process-add`, configure `cargo-process-favorite-crates`.
-

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -39,6 +39,7 @@
 ;;  * cargo-process-repeat             - Run the last cargo-process command.
 ;;  * cargo-process-current-test       - Run the current unit test.
 ;;  * cargo-process-current-file-tests - Run the current file unit tests.
+;;  * cargo-process-expand             - Run the optional cargo command expand.
 ;;  * cargo-process-fmt                - Run the optional cargo command fmt.
 ;;  * cargo-process-check              - Run the optional cargo command check.
 ;;  * cargo-process-clippy             - Run the optional cargo command clippy.
@@ -140,6 +141,9 @@
 
 (defcustom cargo-process--command-update "update"
   "Subcommand used by `cargo-process-update'.")
+
+(defcustom cargo-process--command-expand "expand --color never"
+  "Subcommand used by `cargo-process-expand'.")
 
 (defcustom cargo-process--command-fmt "fmt"
   "Subcommand used by `cargo-process-fmt'.")
@@ -553,6 +557,14 @@ With the prefix argument, modify the command's invocation.
 Cargo: Update dependencies listed in Cargo.lock."
   (interactive)
   (cargo-process--start "Update" cargo-process--command-update))
+
+;;;###autoload
+(defun cargo-process-expand ()
+  "Run the Cargo expand command.
+With the prefix argument, modify the command's invocation.
+Requires cargo-expand to be installed."
+  (interactive)
+  (cargo-process--start "Expand" cargo-process--command-expand))
 
 ;;;###autoload
 (defun cargo-process-fmt ()

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -307,7 +307,7 @@ Execute after PROCESS return and EVENT is 'finished'."
   (cargo-process--expand-finished-sentinel process event)
   (when (equal event "finished\n")
     (goto-char (point-min))
-    (insert "#![feature(box_syntax, test, fmt_internals)]\n")
+    (insert "#![feature(box_syntax, fmt_internals, rustc_attrs, test)]\n")
     (save-buffer)
     (cargo-process--start "Expanded Build" (concat cargo-process--command-current-file-expand-and-compile
                                                    (cargo-process--get-current-file-type)

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -392,11 +392,13 @@ Meant to be run as a `compilation-filter-hook'."
     (error "Cannot expand: current buffer has no file")))
 
 (defun cargo-process--get-current-test-fullname ()
-  (if (cargo-process--get-current-mod)
-      (concat (cargo-process--get-current-mod)
-              "::"
-              (cargo-process--get-current-test))
-    (cargo-process--get-current-test)))
+  "Return the full name of the current test."
+  (let ((current-mod (cargo-process--get-current-mod)))
+    (if current-mod
+        (concat current-mod
+                "::"
+                (cargo-process--get-current-test))
+      (cargo-process--get-current-test))))
 
 (defun cargo-process--maybe-read-command (default)
   "Prompt to modify the DEFAULT command when the prefix argument is present.
@@ -406,8 +408,7 @@ Without the prefix argument, return DEFAULT immediately."
     default))
 
 (defun cargo-process--get-dependencies (&optional manifest)
-  "Extract the list of dependencies from the
-MANIFEST (i.e. Cargo.toml)."
+  "Extract the list of dependencies from the MANIFEST (i.e. Cargo.toml)."
   (with-current-buffer (find-file-noselect (or manifest
                                                (cargo-process--project-root "Cargo.toml")))
     (save-excursion

--- a/cargo.el
+++ b/cargo.el
@@ -40,6 +40,9 @@
 ;;  * C-c C-c C-c - cargo-process-repeat
 ;;  * C-c C-c C-f - cargo-process-current-test
 ;;  * C-c C-c C-o - cargo-process-current-file-tests
+;;  * C-c C-c C-p - cargo-process-expand
+;;  * C-c C-c C-P - cargo-process-current-file-expand
+;;  * C-c C-c M-p - cargo-process-current-file-expand-and-compile
 ;;  * C-c C-c C-m - cargo-process-fmt
 ;;  * C-c C-c C-k - cargo-process-check
 ;;  * C-c C-c C-K - cargo-process-clippy
@@ -82,6 +85,9 @@
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-c") 'cargo-process-repeat)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-f") 'cargo-process-current-test)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-o") 'cargo-process-current-file-tests)
+(define-key cargo-minor-mode-map (kbd "C-c C-c C-p") 'cargo-process-expand)
+(define-key cargo-minor-mode-map (kbd "C-c C-c C-P") 'cargo-process-current-file-expand)
+(define-key cargo-minor-mode-map (kbd "C-c C-c M-p") 'cargo-process-current-file-expand-and-compile)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-m") 'cargo-process-fmt)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-k") 'cargo-process-check)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-S-k") 'cargo-process-clippy)


### PR DESCRIPTION
Expand is really useful for writing macros.

I think it would be neat to have the output buffer be a temporary that was in Rust-mode so that you could get proper syntax highlighting, but I'm not sure of the best way to do that.  Any thoughts?