### PR TITLE
Audit command to check for security vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ You will now have the following key combinations at your disposal:
  <kbd>C-c C-c C-a</kbd> | cargo-process-add
  <kbd>C-c C-c C-S-d</kbd> | cargo-process-rm
  <kbd>C-c C-c C-S-u</kbd> | cargo-process-upgrade
+ <kbd>C-c C-c C-S-a</kbd> | cargo-process-audit
 
 Before executing the task, Emacs will prompt you to save any modified buffers
 associated with the current Cargo project. Setting `compilation-ask-about-save`
@@ -76,6 +77,7 @@ Here's a list of commands and their default value.
 (setq cargo-process--command-add "add")
 (setq cargo-process--command-rm "rm")
 (setq cargo-process--command-upgrade "upgrade")
+(setq cargo-process--command-audit "audit -f")
 ```
 
 ### Advanced usage
@@ -117,3 +119,8 @@ cargo install cargo-edit
 ```
 For completion in `cargo-process-add`, configure `cargo-process-favorite-crates`.
 
+In order to run `cargo-process-audit` you need to have the `audit` package installed.
+
+```
+cargo install cargo-audit
+```

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -46,6 +46,7 @@
 ;;  * cargo-process-rm                 - Run the optional cargo command rm.
 ;;  * cargo-process-upgrade            - Run the optional cargo command upgrade.
 ;;  * cargo-process-outdated           - Run the optional cargo command outdated.
+;;  * cargo-process-audit              - Run the optional cargo command audit.
 
 ;;
 ;;; Code:
@@ -90,7 +91,7 @@
   "Keymap for Cargo major mode.")
 
 (defvar cargo-process--no-manifest-commands
-  '("New" "Init" "Search" "Fmt")
+  '("New" "Init" "Search" "Fmt" "Audit")
   "These commands should not specify a manifest file.")
 
 (defvar cargo-process-last-command nil "Command used last for repeating.")
@@ -162,6 +163,9 @@
 
 (defcustom cargo-process--command-upgrade "upgrade"
   "Subcommand used by `cargo-process-upgrade'.")
+
+(defcustom cargo-process--command-audit "audit -f"
+  "Subcommand used by `cargo-process-audit'.")
 
 (defvar cargo-process-favorite-crates nil)
 
@@ -623,6 +627,17 @@ Cargo: This command allows you to add a dependency to a Cargo.toml manifest file
   (cargo-process--start "Add" (concat cargo-process--command-add
                                       " "
                                       crate)))
+
+;;;###autoload
+(defun cargo-process-audit ()
+  "Run the Cargo audit command.
+With the prefix argument, modify the command's invocation.
+Cargo: Audit checks the current project's Cargo.lock for security vulnerabilities.
+Requires Cargo Audit to be installed."
+  (interactive)
+  (cargo-process--start "Audit" (concat cargo-process--command-audit
+                                        " "
+                                        (cargo-process--project-root "Cargo.lock"))))
 
 ;;;###autoload
 (defun cargo-process-rm (crate)

--- a/cargo.el
+++ b/cargo.el
@@ -47,6 +47,7 @@
 ;;  * C-c C-c C-a - cargo-process-add
 ;;  * C-c C-c C-D - cargo-process-rm
 ;;  * C-c C-c C-U - cargo-process-upgrade
+;;  * C-c C-c C-A - cargo-process-audit
 
 ;;
 ;;; Code:
@@ -90,6 +91,7 @@
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-a") 'cargo-process-add)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-S-d") 'cargo-process-rm)
 (define-key cargo-minor-mode-map (kbd "C-c C-c C-S-u") 'cargo-process-upgrade)
+(define-key cargo-minor-mode-map (kbd "C-c C-c C-S-a") 'cargo-process-audit)
 
 (provide 'cargo)
 ;;; cargo.el ends here


### PR DESCRIPTION
Implemented `cargo-process-audit` to check if any dependency crates of a project has potential security vulnerabilities by checking online advisories.

Added default binding <kbd>C-c C-c C-S-a</kbd>, and that local installation of `cargo audit` is required via `cargo install cargo-audit`.

More info at https://rustsec.org/