### PR TITLE
Describe how to kill running cargo process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ allows you to add flags like `--release`, for example.
 
 Processes run via Cargo mode make use of [compilation mode][]. This
 mode provides features like jumping to errors or killing runaway
-processes.
+processes. By default, in `compilation mode`, <kbd>C-c C-k</kbd> is bound
+to the command `kill-compilation`.
 
 [compilation mode]: https://www.gnu.org/software/emacs/manual/html_node/emacs/Compilation-Mode.html
 


### PR DESCRIPTION
In this commit, I add description on how to `kill-compilation`, which isn't presented in the given [manual](https://www.gnu.org/software/emacs/manual/html_node/emacs/Compilation-Mode.html#Compilation-Mode). I think this can save some time for new users :P