### PR TITLE
Work around Clippy bug that causes missing results

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -176,8 +176,8 @@
   "Subcommand used by `cargo-process-check'."
   :type 'string)
 
-(defcustom cargo-process--command-clippy "clippy"
-  "Subcommand used by `cargo-process-clippy'."
+(defcustom cargo-process--command-clippy "clippy -Zunstable-options"
+  "Subcommand used by `cargo-process-clippy'. Uses `-Zunstable-options` to work around https://github.com/rust-lang/rust-clippy/issues/4612."
   :type 'string)
 
 (defcustom cargo-process--command-add "add"


### PR DESCRIPTION
There is a known issue in `cargo clippy` that this mode is subject to. Details are available at https://github.com/rust-lang/rust-clippy/issues/4612.
The short version: if you run `cargo clippy` twice, or run it after `cargo check`, it does not produce output. This can be fixed by customizing the variable `cargo-process--command-clippy` to be `"clippy -Zunstable-options"`.

I imagine the workaround will eventually become unnecessary once a few things are stabilized, but I have no idea how long that's going to take and it seems to be blocked on other things.