### PR TITLE
Fix cargo over TRAMP.

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -316,6 +316,13 @@ If FILE-NAME is not a TRAMP file, return an empty string."
         (tramp-make-tramp-file-name tramp-file-name))
     ""))
 
+(defun cargo-process--tramp-file-local-name (file-name)
+  "Return the local component of FILE-NAME.
+If FILE-NAME is not a TRAMP file, return it unmodified."
+  (if (tramp-tramp-file-p file-name)
+      (nth 6 (tramp-dissect-file-name file-name))
+    file-name))
+
 (defun cargo-process--workspace-root ()
   "Find the workspace root using `cargo metadata`."
   (when (cargo-process--project-root)
@@ -329,7 +336,7 @@ If FILE-NAME is not a TRAMP file, return an empty string."
       workspace-root)))
 
 (defun manifest-path-argument (name)
-  (let ((manifest-filename (tramp-file-local-name (cargo-process--project-root "Cargo.toml"))))
+  (let ((manifest-filename (cargo-process--tramp-file-local-name (cargo-process--project-root "Cargo.toml"))))
     (when (and manifest-filename
                (not (member name cargo-process--no-manifest-commands)))
       (concat "--manifest-path " (shell-quote-argument manifest-filename)))))

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -309,7 +309,7 @@ for error reporting."
 
 (defun cargo-process--tramp-file-name-prefix (file-name)
   "Return the TRAMP prefix for FILE-NAME.
-If FILE-NAME is not a TRAMP file, return the empty string."
+If FILE-NAME is not a TRAMP file, return an empty string."
   (if (tramp-tramp-file-p file-name)
       (let ((tramp-file-name (tramp-dissect-file-name file-name)))
         (setf (nth 6 tramp-file-name) nil)


### PR DESCRIPTION
* ‘cargo-process--workspace-root’ now returns a path with the TRAMP
  prefix attached, if available.

  In general, we need to preserve TRAMPness for underlying calls to
  Emacs’ ‘compile’ system, so it will know the context in which to
  execute commands, so that’s what we return here, because it’s fed
  directly into compile.

* ‘manifest-path-argument’ strips the TRAMP prefix from the path,
  should it exist.

  Since this path is used for calling to the cargo process in the
  shell, the path must be what cargo itself would see, and so cannot
  contain TRAMPisms.

Closes #113 