### PR TITLE
Avoid positional arguments to define-minor-mode

### DIFF
--- a/cargo.el
+++ b/cargo.el
@@ -101,9 +101,9 @@
   "Cargo minor mode. Used to hold keybindings for cargo-mode.
 
 \\{cargo-minor-mode-command-map}"
-  nil
-  " cargo"
-  cargo-mode-map)
+  :init-value nil
+  :lighter " cargo"
+  :keymap cargo-mode-map)
 
 (provide 'cargo)
 ;;; cargo.el ends here


### PR DESCRIPTION
Back in Emacs-21.1, `define-minor-mode` grew keyword arguments to
replace its old positional arguments.  Starting with Emacs-28.1
warning will be omitted if positional arguments are still used.