### PR TITLE
Make rust-mode optional

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -53,7 +53,6 @@
 
 (require 'compile)
 (require 'button)
-(require 'rust-mode)
 (require 'markdown-mode)
 (require 'tramp)
 
@@ -420,7 +419,12 @@ Meant to be run as a `compilation-filter-hook'."
   "Return the current test."
   (save-excursion
     (unless (cargo-process--defun-at-point-p)
-      (rust-beginning-of-defun))
+      (cond ((fboundp 'rust-beginning-of-defun)
+	     (rust-beginning-of-defun))
+	    ((fboundp 'rustic-beginning-of-defun)
+	     (rustic-beginning-of-defun))
+	    (t (user-error "%s needs either rust-mode or rustic-mode"
+			   this-command))))
     (beginning-of-line)
     (search-forward "fn ")
     (let* ((line (buffer-substring-no-properties (point)

--- a/cargo.el
+++ b/cargo.el
@@ -5,7 +5,7 @@
 ;; Author: Kevin W. van Rooijen
 ;; Version  : 0.4.0
 ;; Keywords: tools
-;; Package-Requires: ((emacs "24.3") (rust-mode "0.2.0") (markdown-mode "2.4"))
+;; Package-Requires: ((emacs "24.3") (markdown-mode "2.4"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Do not depend on `rust-mode` because only a single function from that
package is required by a single function (which in turn is used by a
single command).  Do this so that users who use `rustic`[-mode] can
use `cargo` without having to install `rust-mode' just for that one
function.

Teach `cargo-process--get-current-test` to use the respective `rustic`
function.  If neither package installed then make it instruct the user
to install either one of them.