### PR TITLE
Add support for cargo subcommand 'script' provided by 'cargo-script' binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ You will now have the following key combinations at your disposal:
  <kbd>C-c C-c C-S-d</kbd> | cargo-process-rm
  <kbd>C-c C-c C-S-u</kbd> | cargo-process-upgrade
  <kbd>C-c C-c C-S-a</kbd> | cargo-process-audit
+ <kbd>C-c C-c C-S-r</kbd> | cargo-process-script
 
 Before executing the task, Emacs will prompt you to save any modified buffers
 associated with the current Cargo project. Setting `compilation-ask-about-save`
@@ -90,6 +91,7 @@ Here's a list of commands and their default value.
 (setq cargo-process--command-rm "rm")
 (setq cargo-process--command-upgrade "upgrade")
 (setq cargo-process--command-audit "audit -f")
+(setq cargo-process--command-script "script")
 ```
 
 ### Advanced usage
@@ -123,6 +125,12 @@ In order to run `cargo-process-clippy` you need to have the `clippy` package ins
 
 ```
 cargo install clippy
+```
+
+In order to run `cargo-process-script` you need to have the `cargo-script` package installed.
+
+```
+cargo install cargo-script
 ```
 
 In order to run `cargo-process-{add,rm,upgrade}` you need to have the `cargo-edit` package installed.

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -47,6 +47,7 @@
 ;;  * cargo-process-upgrade            - Run the optional cargo command upgrade.
 ;;  * cargo-process-outdated           - Run the optional cargo command outdated.
 ;;  * cargo-process-audit              - Run the optional cargo command audit.
+;;  * cargo-process-script             - Run the optional cargo command script.
 
 ;;
 ;;; Code:
@@ -194,6 +195,10 @@
 
 (defcustom cargo-process--command-audit "audit -f"
   "Subcommand used by `cargo-process-audit'."
+  :type 'string)
+
+(defcustom cargo-process--command-script "script"
+  "Subcommand used by `cargo-process-script'."
   :type 'string)
 
 (defvar cargo-process-favorite-crates nil)
@@ -724,6 +729,17 @@ Requires Cargo Audit to be installed."
   (cargo-process--start "Audit" (concat cargo-process--command-audit
                                         " "
                                         (cargo-process--project-root "Cargo.lock"))))
+
+;;;###autoload
+(defun cargo-process-script ()
+  "Run the Cargo script command.
+With the prefix argument, modify the command's invocation.
+Cargo: Script compiles and runs 'Cargoified Rust scripts'.
+Requires Cargo Script to be installed."
+  (interactive)
+  (cargo-process--start "Script" (concat cargo-process--command-script
+					 " "
+					 buffer-file-name)))
 
 ;;;###autoload
 (defun cargo-process-rm (crate)

--- a/cargo.el
+++ b/cargo.el
@@ -48,6 +48,7 @@
 ;;  * C-c C-c C-D - cargo-process-rm
 ;;  * C-c C-c C-U - cargo-process-upgrade
 ;;  * C-c C-c C-A - cargo-process-audit
+;;  * C-c C-c C-R - cargo-process-script
 
 ;;
 ;;; Code:
@@ -84,6 +85,7 @@
     (define-key km (kbd "C-S-d") 'cargo-process-rm)
     (define-key km (kbd "C-S-u") 'cargo-process-upgrade)
     (define-key km (kbd "C-S-a") 'cargo-process-audit)
+    (define-key km (kbd "C-S-r") 'cargo-process-script)
     km)
   "Keymap for Cargo mode commands after prefix.")
 (fset 'cargo-minor-mode-command-map cargo-minor-mode-command-map)


### PR DESCRIPTION
Quoting [DanielKeep/cargo-script][cargo-script-readme]:

> `cargo-script` is a Cargo subcommand designed to let people quickly
> and easily run Rust "scripts" which can make use of Cargo's package
> ecosystem.  It can also evaluate expressions and run filters.
>
> Some of `cargo-script`'s features include:
>
> - Reading Cargo manifests embedded in Rust scripts.
> - Caching compiled artefacts (including dependencies) to amortise build times.
> - Supporting executable Rust scripts via UNIX hashbangs and Windows file associations.
> - Evaluating expressions on the command-line.
> - Using expressions as stream filters (*i.e.* for use in command pipelines).
> - Running unit tests and benchmarks from scripts.
> - Custom templates for command-line expressions and filters.

[cargo-script-readme]: https://github.com/DanielKeep/cargo-script/blob/master/README.md

This subcommand can now be invoked for the current file via `C-c C-c C-S-r`.
I find it useful for one-off scripts and experiments.