### PR TITLE
Add new command: cargo-find-dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ You will now have the following key combinations at your disposal:
  <kbd>C-c C-c C-S-a</kbd> | cargo-process-audit
  <kbd>C-c C-c C-S-r</kbd> | cargo-process-script
  <kbd>C-c C-c C-w</kbd> | cargo-process-watch
+ <kbd>C-c C-c C-S-f</kbd> | cargo-find-dependency
 
 Before executing the task, Emacs will prompt you to save any modified buffers
 associated with the current Cargo project. Setting `compilation-ask-about-save`

--- a/cargo-process.el
+++ b/cargo-process.el
@@ -347,6 +347,15 @@ If FILE-NAME is not a TRAMP file, return it unmodified."
                                    (cdr (assoc 'workspace_root metadata-json)))))
       workspace-root)))
 
+(defun cargo-process--get-metadata ()
+  "Return the metadata of the current package as an alist."
+  (when (cargo-process--project-root)
+    (let ((metadata-text
+           (shell-command-to-string
+            (concat (shell-quote-argument cargo-process--custom-path-to-bin)
+                    " metadata --format-version 1"))))
+      (cargo-json-read-from-string metadata-text))))
+
 (defun manifest-path-argument (name)
   (let ((manifest-filename (cargo-process--tramp-file-local-name (cargo-process--project-root "Cargo.toml"))))
     (when (and manifest-filename


### PR DESCRIPTION
I've extracted this from another project of mine.  I hope it is somewhat useful for others.

----

* cargo.el (cargo-find-dependency): New command.
(cargo-minor-mode-command-map): Bind it to C-S-f.

* cargo-process.el (cargo-process--get-metadata): New defun.