### PR TITLE
remove unstable options from clippy command

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -178,8 +178,8 @@
   "Subcommand used by `cargo-process-check'."
   :type 'string)
 
-(defcustom cargo-process--command-clippy "clippy -Zunstable-options"
-  "Subcommand used by `cargo-process-clippy'. Uses `-Zunstable-options` to work around https://github.com/rust-lang/rust-clippy/issues/4612."
+(defcustom cargo-process--command-clippy "clippy"
+  "Subcommand used by `cargo-process-clippy'."
   :type 'string)
 
 (defcustom cargo-process--command-add "add"


### PR DESCRIPTION
This patch removes the `-Zunstable-options` from the default args for
the clippy command.  According to rust-lang/rust-clippy#4612, this
work around is no longer needed.

Fixes: #125