### PR TITLE
Reduce byte-compile warnings

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -159,7 +159,8 @@
   :type 'string)
 
 (defcustom cargo-process--command-test--additional-args nil
-  "Subcommand used by `cargo-process--command-test', `cargo-process--command-current-test` and `cargo-process--command-current-file-tests`.")
+  "Subcommand used by `cargo-process--command-test', `cargo-process--command-current-test` and `cargo-process--command-current-file-tests`."
+  :type 'string)
 
 (defcustom cargo-process--command-update "update"
   "Subcommand used by `cargo-process-update'."
@@ -184,7 +185,8 @@
 (defcustom cargo-process--command-clippy--additional-args nil
   "Subcommand used by `cargo-process-clippy'.
 Changing `cargo-process--command-clippy' use this when trying to customize
-the clippy command so the manifest path is in the correct position.")
+the clippy command so the manifest path is in the correct position."
+  :type 'string)
 
 (defcustom cargo-process--command-add "add"
   "Subcommand used by `cargo-process-add'."
@@ -292,7 +294,7 @@ the clippy command so the manifest path is in the correct position.")
   (font-lock-add-keywords nil cargo-process-font-lock-keywords))
 
 (defun cargo-process--finished-sentinel (process event)
-  "Execute after PROCESS return and EVENT is 'finished'."
+  "Execute after PROCESS return and EVENT is \\='finished\\='."
   (compilation-sentinel process event)
   (when (equal event "finished\n")
     (message "Cargo Process finished.")))
@@ -436,7 +438,7 @@ Returns the created process."
     ("audit" . "cargo-audit")
     ("watch" . "cargo-watch"))
 "Alist of subcommand-component pairs.
-'cargo install COMPONENT' should provide SUBCOMMAND.")
+\\='cargo install COMPONENT\\=' should provide SUBCOMMAND.")
 
 (defun cargo-process--fix-missing-subcommand ()
   "Search complication output for missing subcommand and offer solution.

--- a/cargo.el
+++ b/cargo.el
@@ -55,6 +55,7 @@
 ;;; Code:
 
 (require 'cargo-process)
+(require 'xref)
 
 (defgroup cargo nil
   "Cargo group."


### PR DESCRIPTION
- Specify ':type' attribute for customize variables
- Esacpe single quote in docstring
- Load xref.el to use its functions

```
In cargo-find-dependency:
cargo.el:125:35: Warning: reference to free variable
    ‘xref-show-definitions-function’

In end of data:
cargo.el:129:48: Warning: the function ‘xref-make-file-location’ is not known
    to be defined.
cargo.el:128:37: Warning: the function ‘xref-make’ is not known to be defined.

cargo-process.el:161:12: Warning: defcustom for
    ‘cargo-process--command-test--additional-args’ fails to specify type
cargo-process.el:184:12: Warning: defcustom for
    ‘cargo-process--command-clippy--additional-args’ fails to specify type

In cargo-process--finished-sentinel:
cargo-process.el:294:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)

cargo-process.el:429:2: Warning: defvar `cargo-process--install-cmd-alist'
    docstring has wrong usage of unescaped single quotes (use \= or different
    quoting)
```