### PR TITLE
Add a command for the fix command

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -216,6 +216,10 @@ the clippy command so the manifest path is in the correct position."
   "Subcommand used by `cargo-process-watch'."
   :type 'string)
 
+(defcustom cargo-process--command-fix "fix --allow-staged"
+  "Subcommand used by `cargo-process-fix'."
+  :type 'string)
+
 (defvar cargo-process-favorite-crates nil)
 
 (defface cargo-process--ok-face
@@ -828,6 +832,16 @@ Cargo: Watches over your Cargo project’s source.
 Requires cargo-watch to be installed."
   (interactive)
   (cargo-process--start "Watch" (concat cargo-process--command-watch-run)))
+
+
+;;;###autoload
+(defun cargo-process-fix ()
+  "Run the Cargo fix command.
+With the prefix argument, modify the command's invocation.
+Cargo: Automatically fix lint warnings reported by rustc.
+Allows fixing staged files by default."
+  (interactive)
+  (cargo-process--start "Fix" cargo-process--command-fix))
 
 ;;;###autoload
 (defun cargo-process-rm (crate)

--- a/cargo.el
+++ b/cargo.el
@@ -50,6 +50,7 @@
 ;;  * C-c C-c C-A - cargo-process-audit
 ;;  * C-c C-c C-R - cargo-process-script
 ;;  * C-c C-c C-w - cargo-process-watch
+;;  * C-c C-c C-x - cargo-process-fix
 
 ;;
 ;;; Code:
@@ -89,6 +90,7 @@
     (define-key km (kbd "C-S-a") 'cargo-process-audit)
     (define-key km (kbd "C-S-r") 'cargo-process-script)
     (define-key km (kbd "C-w") 'cargo-process-watch)
+    (define-key km (kbd "C-x") 'cargo-process-fix)
     (define-key km (kbd "C-S-f") 'cargo-find-dependency)
     km)
   "Keymap for Cargo mode commands after prefix.")


### PR DESCRIPTION
This adds a function to call cargo fix in the current project.

I needed a binding to use cargo fix in my projects, and I thought it could potentially benefit other people. Don't hesitate to close the PR if this is not welcome or this matter was already settled and I missed it.

I took the decision to allow staged files to be fixed by default, as that was more useful for me, but I'm open to discussion, of course. It could also be done by the prefix argument (e.g. 4 is, as always, customize the cargo command, but 16 could be allow-dirty and 64 don't allow anything, or in another order)