### PR TITLE
Revert incorrect implementation of "scroll to the end of buffer"

### DIFF
--- a/cargo-process.el
+++ b/cargo-process.el
@@ -394,7 +394,6 @@ Returns the created process."
     (let ((default-directory (or (cargo-process--workspace-root)
                                  default-directory)))
       (compilation-start cmd 'cargo-process-mode (lambda(_) buffer)))
-    (end-of-buffer-other-window buffer)
     (let ((process (get-buffer-process buffer)))
       (set-process-sentinel process 'cargo-process--finished-sentinel)
       process)))


### PR DESCRIPTION
This reverts commit 8e054492e718a66a8407e68a9d4f3f21f0e5cf10.

There are two issues in this commit:

1. The scrolling behavior of buffers related to `compilation-mode` is controlled by `compilation-scroll-output`, and there is no need to add modifications (the variable can be set to `first-error` or `end-of-buffer`, etc.).
2. I am unsure why `(end-of-buffer-other-window buffer)` is used here (where `buffer` is `*Cargo-...*`). This code does not scroll the compilation results window as intended; instead, it erroneously scrolls the code window, which is problematic in itself.

Based on the above points, I have reverted this commit.